### PR TITLE
Add question duplication feature

### DIFF
--- a/src/components/survey-generator/question-blocks/choice.tsx
+++ b/src/components/survey-generator/question-blocks/choice.tsx
@@ -68,7 +68,12 @@ export const ChoiceFormField = ({ questionIndex, form }: Props) => {
 
   const duplicateQuestion = () => {
     const question = form.state.values.questions[questionIndex];
-    form.insertFieldValue("questions", questionIndex + 1, { ...question, id: generateId() }, { touch: true });
+    form.pushFieldValue("questions", { ...question, id: generateId() });
+    form.moveFieldValues(
+      "questions",
+      form.state.values.questions.length - 1,
+      questionIndex + 1
+    );
   };
 
   return (
@@ -187,7 +192,7 @@ export const ChoiceFormField = ({ questionIndex, form }: Props) => {
                                 selector={(state) =>
                                   (
                                     state.values.questions[
-                                    questionIndex
+                                      questionIndex
                                     ] as ChoiceQuestion
                                   ).variant
                                 }

--- a/src/components/survey-generator/question-blocks/choice.tsx
+++ b/src/components/survey-generator/question-blocks/choice.tsx
@@ -22,6 +22,7 @@ import {
   ChevronDown,
   LucideIcon,
   X,
+  Copy,
 } from "lucide-react";
 import { useState } from "react";
 import {
@@ -65,6 +66,11 @@ const iconClassName = "text-muted-foreground";
 export const ChoiceFormField = ({ questionIndex, form }: Props) => {
   const [isVariantSelectorOpen, setIsVarianSelectorOpen] = useState(false);
 
+  const duplicateQuestion = () => {
+    const question = form.state.values.questions[questionIndex];
+    form.insertFieldValue("questions", questionIndex + 1, { ...question, id: generateId() }, { touch: true });
+  };
+
   return (
     <QuestionCard key={questionIndex}>
       <QuestionCardButtonsBar>
@@ -82,6 +88,10 @@ export const ChoiceFormField = ({ questionIndex, form }: Props) => {
           )}
         />
         <Separator orientation="vertical" />
+        <QuestionCardBarButton
+          onClick={duplicateQuestion}
+          children={<Copy />}
+        />
         <QuestionCardBarButton
           onClick={() => form.removeFieldValue(`questions`, questionIndex)}
           children={<X />}
@@ -177,7 +187,7 @@ export const ChoiceFormField = ({ questionIndex, form }: Props) => {
                                 selector={(state) =>
                                   (
                                     state.values.questions[
-                                      questionIndex
+                                    questionIndex
                                     ] as ChoiceQuestion
                                   ).variant
                                 }

--- a/src/components/survey-generator/question-blocks/text.tsx
+++ b/src/components/survey-generator/question-blocks/text.tsx
@@ -24,7 +24,12 @@ type Props = {
 export const TextFormField = ({ questionIndex, form }: Props) => {
   const duplicateQuestion = () => {
     const question = form.state.values.questions[questionIndex];
-    form.insertFieldValue("questions", questionIndex + 1, { ...question, id: generateId() }, { touch: true });
+    form.pushFieldValue("questions", { ...question, id: generateId() });
+    form.moveFieldValues(
+      "questions",
+      form.state.values.questions.length - 1,
+      questionIndex + 1
+    );
   };
 
   return (

--- a/src/components/survey-generator/question-blocks/text.tsx
+++ b/src/components/survey-generator/question-blocks/text.tsx
@@ -4,7 +4,7 @@ import { Switch } from "@/components/ui/switch";
 import { SurveyDefinition } from "@/types/survey";
 import { FormApi } from "@tanstack/react-form";
 import { valibotValidator } from "@tanstack/valibot-form-adapter";
-import { X } from "lucide-react";
+import { Copy, X } from "lucide-react";
 import {
   QuestionCard,
   QuestionCardBarButton,
@@ -14,6 +14,7 @@ import {
   QuestionCardTitle,
 } from "../question-card";
 import { Separator } from "@/components/ui/separator";
+import { generateId } from "@/lib/utils";
 
 type Props = {
   questionIndex: number;
@@ -21,6 +22,11 @@ type Props = {
 };
 
 export const TextFormField = ({ questionIndex, form }: Props) => {
+  const duplicateQuestion = () => {
+    const question = form.state.values.questions[questionIndex];
+    form.insertFieldValue("questions", questionIndex + 1, { ...question, id: generateId() }, { touch: true });
+  };
+
   return (
     <QuestionCard>
       <QuestionCardButtonsBar>
@@ -38,6 +44,10 @@ export const TextFormField = ({ questionIndex, form }: Props) => {
           )}
         />
         <Separator orientation="vertical" />
+        <QuestionCardBarButton
+          onClick={duplicateQuestion}
+          children={<Copy />}
+        />
         <QuestionCardBarButton
           onClick={() => form.removeFieldValue(`questions`, questionIndex)}
           children={<X />}


### PR DESCRIPTION
Related to #5

Adds duplication functionality to both text and choice question types in the survey generator, allowing users to duplicate questions directly from the UI.

- Implements a new duplication button in the `QuestionCardButtonsBar` for both `TextFormField` and `ChoiceFormField` components. This button uses the `Copy` icon from `lucide-react`.
- Adds duplication logic in the `onClick` handler of the new button, which duplicates the question using the `form.insertFieldValue` method from TanStack Form API. The duplicated question is inserted right below the original question, with a new unique ID generated for it using the `generateId` function.
- Maintains the existing functionality and structure of the question cards, ensuring that the addition of the duplication feature integrates seamlessly with the current design and operations.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DevLeonardoCommunity/survey-generator/issues/5?shareId=55cd2cce-3ec7-46ad-80d9-4b375abacce5).